### PR TITLE
Use event in webhook api instead of changesets

### DIFF
--- a/src/main/java/sonia/scm/webhook/AvailableWebHookSpecifications.java
+++ b/src/main/java/sonia/scm/webhook/AvailableWebHookSpecifications.java
@@ -25,8 +25,11 @@
 package sonia.scm.webhook;
 
 import com.google.inject.Inject;
+import sonia.scm.repository.Repository;
 
+import java.util.Collection;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class AvailableWebHookSpecifications {
 
@@ -42,6 +45,14 @@ public class AvailableWebHookSpecifications {
       .filter(specification -> specification.getSpecificationType().getSimpleName().equals(name))
       .findFirst()
       .orElseThrow(() -> new UnknownWebHookException(name));
+  }
+
+  public Collection<String> getTypesFor(Repository repository) {
+    return specifications.stream()
+      .filter(specification -> specification.supportsRepository(repository))
+      .map(WebHookSpecification::getSpecificationType)
+      .map(Class::getSimpleName)
+      .collect(Collectors.toList());
   }
 
   public static String nameOf(WebHookSpecification specification) {

--- a/src/main/java/sonia/scm/webhook/RepositoryWebHook.java
+++ b/src/main/java/sonia/scm/webhook/RepositoryWebHook.java
@@ -81,6 +81,7 @@ public class RepositoryWebHook {
         .stream()
         .filter(provider -> provider.handles(webHook.getConfiguration().getClass()))
         .findFirst()
+        .filter(specification -> specification.supportsRepository(repository))
         .orElseGet(NoSpecificationFound::new)
         .createExecutor(webHook.getConfiguration(), repository, event)
         .run();

--- a/src/main/java/sonia/scm/webhook/SimpleWebHookExecutor.java
+++ b/src/main/java/sonia/scm/webhook/SimpleWebHookExecutor.java
@@ -47,8 +47,11 @@ class SimpleWebHookExecutor implements WebHookExecutor {
   private final Repository repository;
   private final SimpleWebHook webHook;
 
-  SimpleWebHookExecutor(WebHookHttpClient httpClient, ElParser elParser,
-                               SimpleWebHook webHook, Repository repository, Iterable<Changeset> changesets) {
+  SimpleWebHookExecutor(WebHookHttpClient httpClient,
+                        ElParser elParser,
+                        SimpleWebHook webHook,
+                        Repository repository,
+                        Iterable<Changeset> changesets) {
     this.httpClient = httpClient;
     this.expression = elParser.parse(webHook.getUrlPattern());
     this.webHook = webHook;

--- a/src/main/java/sonia/scm/webhook/WebHookSpecification.java
+++ b/src/main/java/sonia/scm/webhook/WebHookSpecification.java
@@ -25,7 +25,7 @@
 package sonia.scm.webhook;
 
 import sonia.scm.plugin.ExtensionPoint;
-import sonia.scm.repository.Changeset;
+import sonia.scm.repository.PostReceiveRepositoryHookEvent;
 import sonia.scm.repository.Repository;
 
 @ExtensionPoint
@@ -36,5 +36,5 @@ public interface WebHookSpecification<T extends SingleWebHookConfiguration> {
     return getSpecificationType().isAssignableFrom(webHookClass);
   }
 
-  WebHookExecutor createExecutor(T webHook, Repository repository, Iterable< Changeset > changesets);
+  WebHookExecutor createExecutor(T webHook, Repository repository, PostReceiveRepositoryHookEvent event);
 }

--- a/src/main/java/sonia/scm/webhook/WebHookSpecification.java
+++ b/src/main/java/sonia/scm/webhook/WebHookSpecification.java
@@ -36,5 +36,9 @@ public interface WebHookSpecification<T extends SingleWebHookConfiguration> {
     return getSpecificationType().isAssignableFrom(webHookClass);
   }
 
+  default boolean supportsRepository(Repository repository) {
+    return true;
+  }
+
   WebHookExecutor createExecutor(T webHook, Repository repository, PostReceiveRepositoryHookEvent event);
 }

--- a/src/main/java/sonia/scm/webhook/internal/WebHookConfigurationResourceLinks.java
+++ b/src/main/java/sonia/scm/webhook/internal/WebHookConfigurationResourceLinks.java
@@ -52,15 +52,15 @@ public class WebHookConfigurationResourceLinks {
 
   public class RepositoryConfigurationLinks {
 
-    public String self(String namespase, String name) {
+    public String self(String namespace, String name) {
       return linkBuilder
-        .method("getRepositoryConfiguration").parameters(namespase, name)
+        .method("getRepositoryConfiguration").parameters(namespace, name)
         .href();
     }
 
-    public String update(String namespase, String name) {
+    public String update(String namespace, String name) {
       return linkBuilder
-        .method("updateRepositoryConfiguration").parameters(namespase, name)
+        .method("updateRepositoryConfiguration").parameters(namespace, name)
         .href();
     }
   }

--- a/src/main/js/AddWebHookButton.tsx
+++ b/src/main/js/AddWebHookButton.tsx
@@ -25,8 +25,10 @@ import React, { FC, useState } from "react";
 import { AddButton, Select } from "@scm-manager/ui-components";
 import { useTranslation } from "react-i18next";
 import { ExtensionPointDefinition, useBinder } from "@scm-manager/ui-extensions";
+import { Repository } from "@scm-manager/ui-types";
 
 type Props = {
+  repository?: Repository;
   readOnly: boolean;
   onAdd: (webHookName: string) => void;
 };
@@ -39,16 +41,19 @@ export type WebHookConfiguration = ExtensionPointDefinition<
   }
 >;
 
-const AddWebHookButton: FC<Props> = ({ readOnly, onAdd }) => {
+const AddWebHookButton: FC<Props> = ({ readOnly, onAdd, repository }) => {
   const { t } = useTranslation("plugins");
   const binder = useBinder();
   const [selectedWebHook, setSelectedWebHook] = useState(0);
 
-  const availableWebHooks = binder.getExtensions<WebHookConfiguration>("webhook.configurations");
+  const allWebHooks = binder.getExtensions<WebHookConfiguration>("webhook.configurations");
+  const availableWebHooks = repository
+    ? repository._embedded.supportedWebHookTypes.types
+    : allWebHooks.map(type => type.name);
   const options = availableWebHooks.map(hook => {
     return {
-      value: hook.name,
-      label: t(`webhooks.${hook.name}.name`)
+      value: hook,
+      label: t(`webhooks.${hook}.name`)
     };
   });
 
@@ -57,13 +62,13 @@ const AddWebHookButton: FC<Props> = ({ readOnly, onAdd }) => {
       <Select
         className={"mr-2"}
         options={options}
-        value={availableWebHooks[selectedWebHook].name}
+        value={allWebHooks[selectedWebHook].name}
         onChange={selected => setSelectedWebHook(options.findIndex(option => option.value === selected))}
       />
       <AddButton
         disabled={readOnly}
         label={t("scm-webhook-plugin.add")}
-        action={() => onAdd(availableWebHooks[selectedWebHook])}
+        action={() => onAdd(allWebHooks[selectedWebHook])}
       />
     </div>
   );

--- a/src/main/js/WebHookConfigurationComponent.tsx
+++ b/src/main/js/WebHookConfigurationComponent.tsx
@@ -36,14 +36,14 @@ type Props = WithTranslation & {
 
 class WebHookConfigurationComponent extends React.Component<Props> {
   render() {
-    const { t, link } = this.props;
+    const { t, link, repository } = this.props;
     return (
       <>
         {this.renderTitle()}
         {this.renderSubtitle()}
         <h2>{t("scm-webhook-plugin.helpText")}</h2>
         <br />
-        <Configuration link={link} render={props => <WebHookConfigurationsForm {...props} />} />
+        <Configuration link={link} render={props => <WebHookConfigurationsForm {...props} repository={repository} />} />
       </>
     );
   }

--- a/src/main/js/WebHookConfigurationsForm.tsx
+++ b/src/main/js/WebHookConfigurationsForm.tsx
@@ -27,8 +27,10 @@ import { WebHookConfiguration, WebHookConfigurations } from "./WebHookConfigurat
 import { confirmAlert, Level } from "@scm-manager/ui-components";
 import AddWebHookButton from "./AddWebHookButton";
 import { WebHookListConfigurationForm } from "./WebHookListConfigurationForm";
+import { Repository } from "@scm-manager/ui-types";
 
 type Props = WithTranslation & {
+  repository?: Repository;
   initialConfiguration: WebHookConfigurations;
   readOnly: boolean;
   onConfigurationChange: (p1: WebHookConfigurations, p2: boolean) => void;
@@ -104,7 +106,7 @@ class WebHookConfigurationsForm extends React.Component<Props, State> {
 
   render() {
     const { editorStates } = this.state;
-    const { readOnly } = this.props;
+    const { readOnly, repository } = this.props;
 
     const addButton = readOnly ? null : (
       <Level
@@ -119,6 +121,7 @@ class WebHookConfigurationsForm extends React.Component<Props, State> {
               });
               this.updateWebHooks(editorStates);
             }}
+            repository={repository}
           />
         }
       />

--- a/src/test/java/sonia/scm/webhook/RepositoryLinkEnricherTest.java
+++ b/src/test/java/sonia/scm/webhook/RepositoryLinkEnricherTest.java
@@ -27,11 +27,13 @@ import com.github.sdorra.shiro.ShiroRule;
 import com.github.sdorra.shiro.SubjectAware;
 import com.google.inject.Provider;
 import com.google.inject.util.Providers;
+import de.otto.edison.hal.HalRepresentation;
 import org.apache.shiro.util.ThreadContext;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import sonia.scm.api.v2.resources.HalAppender;
@@ -40,9 +42,14 @@ import sonia.scm.api.v2.resources.ScmPathInfoStore;
 import sonia.scm.repository.Repository;
 
 import java.net.URI;
+import java.util.Arrays;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @SubjectAware(configuration = "classpath:sonia/scm/webhook/internal/shiro.ini")
 @RunWith(MockitoJUnitRunner.class)
@@ -55,7 +62,11 @@ public class RepositoryLinkEnricherTest {
 
   @Mock
   private HalAppender appender;
+  @Mock
+  private AvailableWebHookSpecifications availableSpecifications;
   private RepositoryLinkEnricher enricher;
+
+  private final Repository repo = new Repository("id", "type", "space", "name");
 
   public RepositoryLinkEnricherTest() {
     // cleanup state that might have been left by other tests
@@ -69,25 +80,39 @@ public class RepositoryLinkEnricherTest {
     ScmPathInfoStore scmPathInfoStore = new ScmPathInfoStore();
     scmPathInfoStore.set(() -> URI.create("https://scm-manager.org/scm/api/"));
     scmPathInfoStoreProvider = Providers.of(scmPathInfoStore);
+    enricher = new RepositoryLinkEnricher(scmPathInfoStoreProvider, availableSpecifications);
   }
 
   @Test
   @SubjectAware( username = "trillian", password = "secret")
   public void shouldEnrichIndex() {
-    enricher = new RepositoryLinkEnricher(scmPathInfoStoreProvider);
-    Repository repo = new Repository("id", "type" , "space", "name");
     HalEnricherContext context = HalEnricherContext.of(repo);
+
     enricher.enrich(context, appender);
+
     verify(appender).appendLink("webHookConfig", "https://scm-manager.org/scm/api/v2/plugins/webhook/space/name");
   }
 
   @Test
   @SubjectAware(username = "unpriv", password = "secret")
   public void shouldNotEnrichIndexBecauseOfMissingPermission() {
-    enricher = new RepositoryLinkEnricher(scmPathInfoStoreProvider);
-    Repository repo = new Repository("id", "type" , "space", "name");
     HalEnricherContext context = HalEnricherContext.of(repo);
+
     enricher.enrich(context, appender);
+
     verify(appender, never()).appendLink("webHookConfig", "https://scm-manager.org/scm/api/v2/plugins/webhook/space/name");
+  }
+
+  @Test
+  @SubjectAware(username = "trillian", password = "secret")
+  public void shouldEnrichEmbeddedWithTypes() {
+    HalEnricherContext context = HalEnricherContext.of(repo);
+    ArgumentCaptor<HalRepresentation> captor = ArgumentCaptor.forClass(HalRepresentation.class);
+    doNothing().when(appender).appendEmbedded(eq("supportedWebHookTypes"), captor.capture());
+    when(availableSpecifications.getTypesFor(repo)).thenReturn(Arrays.asList("simple", "complex"));
+
+    enricher.enrich(context, appender);
+
+    assertThat(captor.getValue()).extracting("types").asList().contains("simple", "complex");
   }
 }

--- a/src/test/java/sonia/scm/webhook/SimpleWebHookSpecificationTest.java
+++ b/src/test/java/sonia/scm/webhook/SimpleWebHookSpecificationTest.java
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-present Cloudogu GmbH and Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package sonia.scm.webhook;
 
 import com.cloudogu.scm.el.ElParser;

--- a/src/test/java/sonia/scm/webhook/SimpleWebHookSpecificationTest.java
+++ b/src/test/java/sonia/scm/webhook/SimpleWebHookSpecificationTest.java
@@ -1,0 +1,61 @@
+package sonia.scm.webhook;
+
+import com.cloudogu.scm.el.ElParser;
+import com.google.inject.Provider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sonia.scm.repository.Changeset;
+import sonia.scm.repository.PostReceiveRepositoryHookEvent;
+import sonia.scm.repository.Repository;
+import sonia.scm.repository.RepositoryTestData;
+import sonia.scm.repository.api.HookChangesetBuilder;
+import sonia.scm.repository.api.HookContext;
+import sonia.scm.repository.api.HookFeature;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SimpleWebHookSpecificationTest {
+
+  @Mock
+  private Provider<WebHookHttpClient> httpClientProvider;
+  @Mock
+  private ElParser elParser;
+
+  @Mock
+  private PostReceiveRepositoryHookEvent event;
+  @Mock
+  private HookContext eventContext;
+  @Mock(answer = Answers.RETURNS_SELF)
+  private HookChangesetBuilder changesetBuilder;
+
+  private final Repository repository = RepositoryTestData.createHeartOfGold();
+
+  @BeforeEach
+  void initEvent() {
+    when(event.getContext()).thenReturn(eventContext);
+    when(eventContext.isFeatureSupported(HookFeature.CHANGESET_PROVIDER)).thenReturn(true);
+    when(eventContext.getChangesetProvider()).thenReturn(changesetBuilder);
+    when(changesetBuilder.getChangesets())
+      .thenReturn(singletonList(new Changeset("42", 0L, null)));
+  }
+
+  @Test
+  void shouldGetChangesetsFromEvent() {
+    SimpleWebHookSpecification specification = new SimpleWebHookSpecification(httpClientProvider, elParser);
+
+    SimpleWebHookExecutor executor = (SimpleWebHookExecutor) specification.createExecutor(new SimpleWebHook(), repository, event);
+
+    assertThat(executor).extracting("repository").isSameAs(repository);
+    assertThat(executor).extracting("changesets")
+      .asList()
+      .extracting("id")
+      .containsExactly("42");
+  }
+}


### PR DESCRIPTION
## Proposed changes

Not all webhooks are interested in changesets, but may have the need for changed branches. To support this, we change the extension API so that it no longer provides the changesets, but the event itself.

In addition this has the benefit, that the changesets do not have to be computed for webhooks that are not interested in them.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [x] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [ ] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
